### PR TITLE
Add test and implement for randomChance default behaviour of 0.5 (#5)

### DIFF
--- a/source/Random.js
+++ b/source/Random.js
@@ -58,7 +58,7 @@ export class PRNG {
         return array[index];
     }
 
-    randomChance(chance) {
+    randomChance(chance = 0.5) {
         return this.randomFloat() < chance;
     }
 }

--- a/source/tests/unit/randomChance.test.js
+++ b/source/tests/unit/randomChance.test.js
@@ -1,6 +1,6 @@
 import { Mulberry32 } from "../../Random";
 
-describe("The randomChance method", () =>{
+describe("The randomChance method", () => {
     test("Returns True if the chance parameter it is given is greater than a random float between 0 and 1", () => {
         let prng = new Mulberry32();
 
@@ -11,5 +11,12 @@ describe("The randomChance method", () =>{
     test("Always returns a boolean", () => {
         let prng = new Mulberry32();
         expect(typeof prng.randomChance(0.5)).toBe("boolean")
-    })
-})
+    });
+
+    test("If called without argument, the default behaviour is 50/50 True or False", () => {
+        let prng1 = new Mulberry32(1);
+        let prng2 = new Mulberry32(1);
+
+        expect(prng1.randomChance()).toBe(prng2.randomChance(0.5));
+    });
+});


### PR DESCRIPTION
This is a very small feature whereby the prng.randomChance() function can be called without argument to get a default behaviour that returns T ~50% of the time, as described in (#5).

The test for this function makes two identical PRNGs, and then calls the first with randomChance() method (without argument) and calls the second PRNG with randomChance(0.5). These two outputs are expected to be identical.